### PR TITLE
Ensure getPixel uses only local variables for speed

### DIFF
--- a/src/qrcode.js
+++ b/src/qrcode.js
@@ -165,9 +165,8 @@ this.getPixel = function(imageData, x,y){
 	if (imageData.height < y) {
 		throw "point error";
 	}
-	point = (x * 4) + (y * imageData.width * 4);
-	p = (imageData.data[point]*33 + imageData.data[point + 1]*34 + imageData.data[point + 2]*33)/100;
-	return p;
+	var point = (x * 4) + (y * imageData.width * 4);
+	return (imageData.data[point]*33 + imageData.data[point + 1]*34 + imageData.data[point + 2]*33)/100;
 }
 
 this.binarize = function(th){


### PR DESCRIPTION
After testing on Chrome for Android (50.0.2661.89) on a Nexus 5X I noticed it was taking around 1000-1200ms to process a 240x320 frame.
After digging in a bit more it seemed to be time spent in `grayscale()`.
Once I stopped `getPixel()` assigning global variables it now takes 120-200ms to process the same frame.
