### PR TITLE
Small tweak to provide access to coordinates

### DIFF
--- a/src/qrcode.js
+++ b/src/qrcode.js
@@ -153,7 +153,7 @@ QrCode.prototype.process = function(imageData) {
     console.log('QR Code processing time (ms): ' + time);
   }
 
-  return this.decode_utf8(str);
+  return {url: this.decode_utf8(str), points: qrCodeMatrix.bits};
 };
 
 QrCode.prototype.getPixel = function(imageData, x, y) {

--- a/src/qrcode.js
+++ b/src/qrcode.js
@@ -153,7 +153,7 @@ QrCode.prototype.process = function(imageData) {
     console.log('QR Code processing time (ms): ' + time);
   }
 
-  return {url: this.decode_utf8(str), points: qrCodeMatrix.bits};
+  return {url: this.decode_utf8(str), points: qRCodeMatrix.points};
 };
 
 QrCode.prototype.getPixel = function(imageData, x, y) {


### PR DESCRIPTION
Expose internal qr code coordinates. Extremely useful in light of ShapeDetection API work, given that spec (available at https://wicg.github.io/shape-detection-api/#barcode-detection-api) requires the barcode rectangle, raw string and point array.