### PR TITLE
Correct license

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/edi9999/jsqrcode.git"
   },
   "author": "",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/edi9999/jsqrcode/issues"
   },


### PR DESCRIPTION
You had the [wrong license](https://github.com/edi9999/jsqrcode/blob/master/COPYING) in there…